### PR TITLE
Do not show typing animation when there is only one initial passage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ var Story = window.Story = require('./story');
 var Passage = window.Passage = require('./passage');
 
 $(function() {
+	$('#animation-container').hide();
 	window.story = new Story();
 	window.story.start();
 });


### PR DESCRIPTION
Fixes bug #2 in which a single initial passage followed by user responses displays the typing animation.

The fix is just to hide the typing animation before setting up the story.