### PR TITLE
Add max passage delay

### DIFF
--- a/src/story.js
+++ b/src/story.js
@@ -209,6 +209,15 @@ var Story = function() {
 
 	this.delayedPassageEvent = null;
 
+	/**
+	 The maximum amount of time in milliseconds that a passage will be delayed
+
+	 @property maxPassageDelay
+	 @type Number
+	**/
+
+	this.maxPassageDelay = 10000;
+
 	var p = this.passages;
 
 	if (twVersion == 2) {
@@ -733,8 +742,8 @@ _.extend(Story.prototype, {
 		var targetTextLength = targetSourceTextLength - targetUserResponseLength;
 		var msPerChar = 20;
 		var delayMS = targetTextLength * msPerChar;
-
-		return delayMS;
+		var delayThresholded = Math.min(delayMS, this.maxPassageDelay);
+		return delayThresholded;
 	},
 
 	/**

--- a/src/story.js
+++ b/src/story.js
@@ -129,13 +129,13 @@ var Story = function() {
 
 	/**
    An array of passage IDs, one for each passage viewed since 
-the last response.
+	 the last response.
 
    @property recent
    @type Array
   **/
 
-        this.recent = [];
+  this.recent = [];
 
 	/**
 	 An object that stores data that persists across a single user session.

--- a/src/story.js
+++ b/src/story.js
@@ -128,12 +128,12 @@ var Story = function() {
 	this.recent_dom = [];
 
 	/**
-         An array of passage IDs, one for each passage viewed since 
-	 the last response.
+   An array of passage IDs, one for each passage viewed since 
+the last response.
 
-         @property recent
-         @type Array
-        **/
+   @property recent
+   @type Array
+  **/
 
         this.recent = [];
 


### PR DESCRIPTION
set window.story.maxPassageDelay to a large default value of 10000 millisecods.
Can be overwritten in Story Javascript like so:
```
window.story.maxPassageDelay = 5000;
```

fixes https://github.com/phivk/trialogue/issues/21