### PR TITLE
Fix - misaligned position of undo button in navbar

### DIFF
--- a/src/trialogue.css
+++ b/src/trialogue.css
@@ -94,6 +94,7 @@ nav .nav-icon {
 
 nav a.content-container:not(:first-child) {
   padding-left: 0.5em;
+  margin-right: auto;
 }
 
 /* Chat Panel */


### PR DESCRIPTION
Fix of issue #35  opened by @phivk

Added margin-right CSS tag to class to automatically align it far left trough margin.

> `
> nav a.content-container:not(:first-child) {
>   padding-left: 0.5em;
>   margin-right: auto;
> }
> `

![image](https://user-images.githubusercontent.com/89909595/176142529-98007ec9-8c43-4c78-b989-dcc22e5c4def.png)