### PR TITLE
update marked parse usage

### DIFF
--- a/src/passage.js
+++ b/src/passage.js
@@ -108,7 +108,7 @@ function render(source) {
 		}
 	});
 
-	return marked(result);
+	return marked.parse(result);
 };
 
 /**


### PR DESCRIPTION
turns out the API of the Marked library changed from `marked()` to `marked.parse()`
https://marked.js.org/#usage

fixes https://github.com/phivk/trialogue/issues/37